### PR TITLE
API Error message

### DIFF
--- a/src/ReviewService.php
+++ b/src/ReviewService.php
@@ -44,7 +44,12 @@ class ReviewService {
     $created_reviews = 0;
     foreach ($place_id_list as $place_id) {
       $result = $this->importReview($client, $place_id, $api_key);
-      if ($result && !empty($result['result']['reviews'])) {
+      if ($result && !empty($result['error_message'])) {
+        \Drupal::messenger()->addError(
+          'API ERROR: ' . $result['error_message']
+        );
+      }
+      elseif ($result && !empty($result['result']['reviews'])) {
         foreach ($result['result']['reviews'] as $review) {
           if (!$this->isCreated($review)) {
             $this->createReview($review);


### PR DESCRIPTION
When the API returns with an error there is no way of detecting this in the frontend.

Message: "0 reviews imported."

I added a flash message  (Drupal messenger) that presents the error.